### PR TITLE
Remove npmusic

### DIFF
--- a/swag/npm
+++ b/swag/npm
@@ -10,7 +10,6 @@ gulp-cli::gulp
 hotel::hotel
 html-sketchapp-cli::html-sketchapp
 imageoptim-cli::imageOptim
-npmusic::npmusic
 pa11y::pa11y
 parrotsay::parrotsay
 vue-cli::vue


### PR DESCRIPTION
Install was blocked by an error installing `npmusic`.  I don't think this doesn't anything important, so let's remove it.