### PR TITLE
PHP and Terraform - remove references to abandoned brews

### DIFF
--- a/slay
+++ b/slay
@@ -243,7 +243,6 @@ if [[ ! $(php --version | grep "PHP 7.4") ]]; then
   brew install shivammathur/php/php@8.2 > /dev/null
 
   # Need to specify this, otherwise it just installs the default 7.3.29 that ships with Big Sur.
-  brew link --force --overwrite php@7.4 > /dev/null
   brew link --overwrite --force shivammathur/php/php@7.4 > /dev/null
   export PATH="/usr/local/opt/php@7.4/bin:$PATH"
   export PATH="/usr/local/opt/php@7.4/sbin:$PATH"

--- a/slay
+++ b/slay
@@ -115,16 +115,6 @@ source $NVM_DIR/nvm.sh
 print_success "NVM installed!"
 
 # -----------------------------------------------------------------------------
-# Node 16 - We need this version for mobile (as of 26/06/2022)
-# -----------------------------------------------------------------------------
-step "Installing Node 16…"
-nvm install 16 > /dev/null
-nvm use 16 > /dev/null
-nvm run node --version > /dev/null
-nodev=$(node -v)
-print_success "Using Node $nodev!"
-
-# -----------------------------------------------------------------------------
 # Homebrew
 # -----------------------------------------------------------------------------
 step "Installing Homebrew…"

--- a/slay
+++ b/slay
@@ -115,6 +115,16 @@ source $NVM_DIR/nvm.sh
 print_success "NVM installed!"
 
 # -----------------------------------------------------------------------------
+# Node 16 - We need this version for mobile (as of 26/06/2022)
+# -----------------------------------------------------------------------------
+step "Installing Node 16…"
+nvm install 16 > /dev/null
+nvm use 16 > /dev/null
+nvm run node --version > /dev/null
+nodev=$(node -v)
+print_success "Using Node $nodev!"
+
+# -----------------------------------------------------------------------------
 # Homebrew
 # -----------------------------------------------------------------------------
 step "Installing Homebrew…"

--- a/slay
+++ b/slay
@@ -228,7 +228,7 @@ fi
 ###############################################################################
 # INSTALL: PHP 7.4
 ###############################################################################
-chapter "Installing correct PHP version…"
+chapter "Installing PHP version 7.4…"
 if [[ ! $(php --version | grep "PHP 7.4") ]]; then
   # Uninstall default PHP that ships with MacOS.
   if brew ls --versions php > /dev/null; then
@@ -236,11 +236,15 @@ if [[ ! $(php --version | grep "PHP 7.4") ]]; then
   fi
 
   echo_install "Installing php@7.4"
-  brew install php@7.4 > /dev/null
+  brew tap shivammathur/php
+  brew install shivammathur/php/php@7.4 > /dev/null
+  brew install shivammathur/php/php@8.0 > /dev/null
+  brew install shivammathur/php/php@8.1 > /dev/null
+  brew install shivammathur/php/php@8.2 > /dev/null
 
   # Need to specify this, otherwise it just installs the default 7.3.29 that ships with Big Sur.
   brew link --force --overwrite php@7.4 > /dev/null
-  brew services start php@7.4 > /dev/null
+  brew link --overwrite --force shivammathur/php/php@7.4 > /dev/null
   export PATH="/usr/local/opt/php@7.4/bin:$PATH"
   export PATH="/usr/local/opt/php@7.4/sbin:$PATH"
   print_success "php@7.4 installed!\n"

--- a/swag/brews
+++ b/swag/brews
@@ -11,7 +11,7 @@ jq
 mas
 npm
 rbenv
-terraform@0.12
+terraform
 tig
 wget
 yarn


### PR DESCRIPTION
PR makes two changes to our formation setup:

- Changes the source of PHP as the offical brew has dropped support for PHP 7.4. Also installs all versions of PHP 8 so we can switch to them later.
- Changes `terraform` from version 0.12 to latest because the 0.12 version of the brew has been dropped. In fact, they completely changed versioning from 0.13.7 to 1.3.7. https://formulae.brew.sh/formula/terraform