### PR TITLE
Remove unneeded npm packages

### DIFF
--- a/swag/npm
+++ b/swag/npm
@@ -1,15 +1,1 @@
-colortest::colortest
-cssstats-cli::cssstats
-@11ty/eleventy::eleventy
-eslint::eslint
-fast-cli::fast
-@frctl/fractal::fractal
-gatsby-cli::gatsby
-git-standup::git-standup
-gulp-cli::gulp
-hotel::hotel
-html-sketchapp-cli::html-sketchapp
-imageoptim-cli::imageOptim
-pa11y::pa11y
-parrotsay::parrotsay
 @vue/cli::vue


### PR DESCRIPTION
These come from the upstream repo and we don't need them globally on our machines