### PR TITLE
Add python-setuptools

### DIFF
--- a/swag/brews
+++ b/swag/brews
@@ -11,3 +11,4 @@ rbenv
 terraform
 wget
 yarn
+python-setuptools


### PR DESCRIPTION
When running `yarn` in `~/workspace/asknicelydo/websrc` I got this error:

```
ModuleNotFoundError: No module named 'distutils' gyp
```

The cause of this error is due to [distutils being removed in Python 3.12.](https://github.com/pypa/setuptools/issues/3661#issuecomment-1744612720)

The workaround is to use setuptools to provide distutils. So I have added python-setuptools to the brew packages.